### PR TITLE
Fixed json_to_roidb.py Bug： has no attribute 'json'

### DIFF
--- a/utils/json_to_roidb.py
+++ b/utils/json_to_roidb.py
@@ -9,8 +9,8 @@ import numpy as np
 def parse_argument():
     parser = argparse.ArgumentParser("Convert json gt to roidb")
     parser.add_argument("--json", type=str, required=True)
-    parser.parse_args()
-    return parser.json
+    args = parser.parse_args()
+    return args.json
 
 
 def json_to_roidb(json_path):


### PR DESCRIPTION
Describe the bug
A clear and concise description of what the bug is.
code in line 12-13

 parser.parse_args()
 return parser.json
are supossed to be change into

arg = parser.parse_args()
return arg.json
or you wil get

AttributeError: 'ArgumentParser' object has no attribute 'json'